### PR TITLE
Fix:css file update for input validation span

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -21,7 +21,7 @@ header {
 
 .container {
     padding-bottom: 20px;
-    margin-top: 10px;
+    margin-top: 50px;
     width: 450px;
     align-items: center;
     display: flex;
@@ -67,7 +67,7 @@ header {
 
 .input-box input:focus + span,
 .input-box input:valid ~ span {
-    transform: translate(8px, -13px);
+    transform: translate(-6px, -19px);
     font-size: 0.80em;
     padding: 0 10px;
     background: none;


### PR DESCRIPTION
Here i have update the css file input type validation span,previously span was overlap the  input field now it is upper portion of a input filed during typing 
![image](https://github.com/nediry/todo-react/assets/71685189/f4786002-0b49-43ab-83f8-9759dd52969d)
